### PR TITLE
Netappfiles update sdk version that include api version 2021 06 01

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,22 @@ Make sure this file is stored at the root of the project.
        >Note: This command will automatically assign RBAC contributor role to the service principal at subscription level.
        You can narrow down the scope to the specific resource group where your tests will create the resources.
 
-    1. Copy the output contents and paste it in a file called azureauth.json, and secure it with file system permissions.
-    1. Set an environment variable pointing to the file path you just created. Here is an example with Powershell and bash:
-        
-        Powershell
-        ```powershell
-        [Environment]::SetEnvironmentVariable("AZURE_AUTH_LOCATION", "C:\sdksample\azureauth.json", "User")
-        ```
-        Bash
-        ```bash
-        export AZURE_AUTH_LOCATION=/sdksamples/azureauth.json
-        ```
+   1. Set the following environment variables from the output of the creation:
+
+      Powershell
+       ```powershell
+       $env:AZURE_SUBSCRIPTION_ID = <subscriptionId>
+       $env:AZURE_CLIENT_ID = <clientId>
+       $env:AZURE_CLIENT_SECRET = <clientSecret>
+       $env:AZURE_TENANT_ID = <tenantId>
+       ```
+      Bash
+       ```bash
+       export AZURE_SUBSCRIPTION_ID=<subscriptionId>
+       export AZURE_CLIENT_ID=<clientId>
+       export AZURE_CLIENT_SECRET=<clientSecret>
+       export AZURE_TENANT_ID=<tenantId>
+       ```
     
 ## What is netappfiles-java-dual-protocol-sdk-sample doing?
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The following table describes all files within this solution:
     git clone https://github.com/Azure-Samples/netappfiles-java-dual-protocol-sdk-sample
     ```
 1. Change folder to **.\netappfiles-java-dual-protocol-sdk-sample**
-1. Make sure you have the azureauth.json and its environment variable with the path to it defined (as previously described)
+1. Make sure you have the environment variables previously described defined.
 1. Make sure the JAVA_HOME environment variable is pointing to version 11 of Java or newer (see Prerequisites for instructions)
 1. In the main.java class, change the values of the variables within the runAsync() function to reflect your environment
 1. Compile the console application

--- a/pom.xml
+++ b/pom.xml
@@ -26,36 +26,25 @@
     <url>http://maven.apache.org</url>
 
     <dependencies>
-
-        <dependency>
-            <groupId>com.ea.async</groupId>
-            <artifactId>ea-async</artifactId>
-            <version>1.2.3</version>
-        </dependency>
-
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.6</version>
         </dependency>
-
         <dependency>
-            <groupId>com.microsoft.azure.netapp.v2020_06_01</groupId>
-            <artifactId>azure-mgmt-netapp</artifactId>
-            <version>1.0.0-beta</version>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>1.3.1</version>
         </dependency>
-
         <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-client-authentication</artifactId>
-            <version>1.7.5</version>
+            <groupId>com.azure.resourcemanager</groupId>
+            <artifactId>azure-resourcemanager-netapp</artifactId>
+            <version>1.0.0-beta.4</version>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.28</version>
         </dependency>
-
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.azure.resourcemanager</groupId>
             <artifactId>azure-resourcemanager-netapp</artifactId>
-            <version>1.0.0-beta.4</version>
+            <version>1.0.0-beta.5</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/dualprotocol/sdk/sample/Cleanup.java
+++ b/src/main/java/dualprotocol/sdk/sample/Cleanup.java
@@ -5,7 +5,7 @@
 
 package dualprotocol.sdk.sample;
 
-import com.microsoft.azure.management.netapp.v2020_06_01.implementation.AzureNetAppFilesManagementClientImpl;
+import com.azure.resourcemanager.netapp.fluent.NetAppManagementClient;
 import dualprotocol.sdk.sample.common.Utils;
 
 import java.util.concurrent.CompletableFuture;
@@ -18,36 +18,33 @@ public class Cleanup
      * @param params String array containing account name, pool name, etc, needed to delete resource
      * @param clazz Which resource is being deleted
      */
-    public static <T> CompletableFuture<Void> runCleanupTask(AzureNetAppFilesManagementClientImpl anfClient, String[] params, Class<T> clazz)
+    public static <T> void runCleanupTask(NetAppManagementClient anfClient, String[] params, Class<T> clazz)
     {
         switch (clazz.getSimpleName())
         {
             case "VolumeInner":
                 Utils.writeConsoleMessage("Deleting Volume...");
-                anfClient.volumes().delete(
+                anfClient.getVolumes().beginDelete(
                         params[0],
                         params[1],
                         params[2],
-                        params[3]);
+                        params[3]).getFinalResult();
                 break;
 
             case "CapacityPoolInner":
                 Utils.writeConsoleMessage("Deleting Capacity Pool...");
-                anfClient.pools().delete(
+                anfClient.getPools().beginDelete(
                         params[0],
                         params[1],
-                        params[2]);
+                        params[2]).getFinalResult();
                 break;
 
             case "NetAppAccountInner":
                 Utils.writeConsoleMessage("Deleting Account...");
-                anfClient.accounts().delete(
+                anfClient.getAccounts().beginDelete(
                         params[0],
-                        params[1]);
+                        params[1]).getFinalResult();
                 break;
-
         }
-
-        return CompletableFuture.completedFuture(null);
     }
 }

--- a/src/main/java/dualprotocol/sdk/sample/Creation.java
+++ b/src/main/java/dualprotocol/sdk/sample/Creation.java
@@ -5,6 +5,7 @@
 
 package dualprotocol.sdk.sample;
 
+import com.azure.core.exception.AzureException;
 import com.azure.resourcemanager.netapp.fluent.NetAppManagementClient;
 import com.azure.resourcemanager.netapp.fluent.models.CapacityPoolInner;
 import com.azure.resourcemanager.netapp.fluent.models.NetAppAccountInner;
@@ -29,7 +30,7 @@ public class Creation
 
             return anfAccount;
         }
-        catch (Exception e)
+        catch (AzureException e)
         {
             Utils.writeConsoleMessage("An error occurred while creating account: " + e.getMessage());
             throw e;
@@ -52,7 +53,7 @@ public class Creation
 
             return capacityPool;
         }
-        catch (Exception e)
+        catch (AzureException e)
         {
             Utils.writeConsoleMessage("An error occurred while creating capacity pool: " + e.getMessage());
             throw e;
@@ -75,7 +76,7 @@ public class Creation
 
             return volume;
         }
-        catch (Exception e)
+        catch (AzureException e)
         {
             Utils.writeConsoleMessage("An error occurred while creating volume: " + e.getMessage());
             throw e;

--- a/src/main/java/dualprotocol/sdk/sample/Creation.java
+++ b/src/main/java/dualprotocol/sdk/sample/Creation.java
@@ -5,11 +5,11 @@
 
 package dualprotocol.sdk.sample;
 
-import com.microsoft.azure.CloudException;
-import com.microsoft.azure.management.netapp.v2020_06_01.implementation.*;
+import com.azure.resourcemanager.netapp.fluent.NetAppManagementClient;
+import com.azure.resourcemanager.netapp.fluent.models.CapacityPoolInner;
+import com.azure.resourcemanager.netapp.fluent.models.NetAppAccountInner;
+import com.azure.resourcemanager.netapp.fluent.models.VolumeInner;
 import dualprotocol.sdk.sample.common.Utils;
-
-import java.util.concurrent.CompletableFuture;
 
 public class Creation
 {
@@ -20,18 +20,18 @@ public class Creation
      * @param accountBody The Account body used in the creation
      * @return The newly created ANF Account
      */
-    public static CompletableFuture<NetAppAccountInner> createANFAccount(AzureNetAppFilesManagementClientImpl anfClient, String[] accountParams, NetAppAccountInner accountBody)
+    public static NetAppAccountInner createANFAccount(NetAppManagementClient anfClient, String[] accountParams, NetAppAccountInner accountBody)
     {
         try
         {
-            NetAppAccountInner anfAccount = anfClient.accounts().createOrUpdate(accountParams[0], accountParams[1], accountBody);
+            NetAppAccountInner anfAccount = anfClient.getAccounts().beginCreateOrUpdate(accountParams[0], accountParams[1], accountBody).getFinalResult();
             Utils.writeSuccessMessage("Account successfully created, resourceId: " + anfAccount.id());
 
-            return CompletableFuture.completedFuture(anfAccount);
+            return anfAccount;
         }
-        catch (CloudException e)
+        catch (Exception e)
         {
-            Utils.writeConsoleMessage("An error occurred while creating account: " + e.body().message());
+            Utils.writeConsoleMessage("An error occurred while creating account: " + e.getMessage());
             throw e;
         }
     }
@@ -43,18 +43,18 @@ public class Creation
      * @param poolBody The Capacity Pool body used in the creation
      * @return The newly created Capacity Pool
      */
-    public static CompletableFuture<CapacityPoolInner> createCapacityPool(AzureNetAppFilesManagementClientImpl anfClient, String[] poolParams, CapacityPoolInner poolBody)
+    public static CapacityPoolInner createCapacityPool(NetAppManagementClient anfClient, String[] poolParams, CapacityPoolInner poolBody)
     {
         try
         {
-            CapacityPoolInner capacityPool = anfClient.pools().createOrUpdate(poolParams[0], poolParams[1], poolParams[2], poolBody);
+            CapacityPoolInner capacityPool = anfClient.getPools().beginCreateOrUpdate(poolParams[0], poolParams[1], poolParams[2], poolBody).getFinalResult();
             Utils.writeSuccessMessage("Capacity Pool successfully created, resourceId: " + capacityPool.id());
 
-            return CompletableFuture.completedFuture(capacityPool);
+            return capacityPool;
         }
-        catch (CloudException e)
+        catch (Exception e)
         {
-            Utils.writeConsoleMessage("An error occurred while creating capacity pool: " + e.body().message());
+            Utils.writeConsoleMessage("An error occurred while creating capacity pool: " + e.getMessage());
             throw e;
         }
     }
@@ -66,18 +66,18 @@ public class Creation
      * @param volumeBody The Volume body used in the creation
      * @return The newly created Volume
      */
-    public static CompletableFuture<VolumeInner> createVolume(AzureNetAppFilesManagementClientImpl anfClient, String[] volumeParams, VolumeInner volumeBody)
+    public static VolumeInner createVolume(NetAppManagementClient anfClient, String[] volumeParams, VolumeInner volumeBody)
     {
         try
         {
-            VolumeInner volume = anfClient.volumes().createOrUpdate(volumeParams[0], volumeParams[1], volumeParams[2], volumeParams[3], volumeBody);
+            VolumeInner volume = anfClient.getVolumes().beginCreateOrUpdate(volumeParams[0], volumeParams[1], volumeParams[2], volumeParams[3], volumeBody).getFinalResult();
             Utils.writeSuccessMessage("Volume successfully created, resourceId: " + volume.id());
 
-            return CompletableFuture.completedFuture(volume);
+            return volume;
         }
-        catch (CloudException e)
+        catch (Exception e)
         {
-            Utils.writeConsoleMessage("An error occurred while creating volume: " + e.body().message());
+            Utils.writeConsoleMessage("An error occurred while creating volume: " + e.getMessage());
             throw e;
         }
     }

--- a/src/main/java/dualprotocol/sdk/sample/common/CommonSdk.java
+++ b/src/main/java/dualprotocol/sdk/sample/common/CommonSdk.java
@@ -5,8 +5,8 @@
 
 package dualprotocol.sdk.sample.common;
 
-import com.microsoft.azure.management.netapp.v2020_06_01.implementation.*;
-import rx.Observable;
+import com.azure.resourcemanager.netapp.fluent.NetAppManagementClient;
+import com.azure.resourcemanager.netapp.fluent.models.*;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -25,57 +25,53 @@ public class CommonSdk
      * @param clazz Valid class types: NetAppAccountInner, CapacityPoolInner, VolumeInner, SnapshotInner, SnapshotPolicyInner
      * @return Valid resource T
      */
-    public static <T> CompletableFuture<T> getResourceAsync(AzureNetAppFilesManagementClientImpl anfClient, String[] parameters, Class<T> clazz)
+    public static <T> Object getResource(NetAppManagementClient anfClient, String[] parameters, Class<T> clazz)
     {
         try
         {
             switch (clazz.getSimpleName())
             {
                 case "NetAppAccountInner":
-                    Observable<NetAppAccountInner> account = anfClient.accounts().getByResourceGroupAsync(
+                    return anfClient.getAccounts().getByResourceGroup(
                             parameters[0],
                             parameters[1]);
-                    return CompletableFuture.completedFuture((T) account.toBlocking().first());
 
                 case "SnapshotPolicyInner":
-                    Observable<SnapshotPolicyInner> snapshotPolicy = anfClient.snapshotPolicies().getAsync(
+                    return anfClient.getSnapshotPolicies().get(
                             parameters[0],
                             parameters[1],
                             parameters[2]);
-                    return CompletableFuture.completedFuture((T) snapshotPolicy.toBlocking().first());
 
                 case "CapacityPoolInner":
-                    Observable<CapacityPoolInner> capacityPool = anfClient.pools().getAsync(
+                    return anfClient.getPools().get(
                             parameters[0],
                             parameters[1],
                             parameters[2]);
-                    return CompletableFuture.completedFuture((T) capacityPool.toBlocking().first());
 
                 case "VolumeInner":
-                    Observable<VolumeInner> volume = anfClient.volumes().getAsync(
+                    return anfClient.getVolumes().get(
                             parameters[0],
                             parameters[1],
                             parameters[2],
                             parameters[3]);
-                    return CompletableFuture.completedFuture((T) volume.toBlocking().first());
 
                 case "SnapshotInner":
-                    Observable<SnapshotInner> snapshot = anfClient.snapshots().getAsync(
+                    return anfClient.getSnapshots().get(
                             parameters[0],
                             parameters[1],
                             parameters[2],
                             parameters[3],
                             parameters[4]);
-                    return CompletableFuture.completedFuture((T) snapshot.toBlocking().first());
             }
         }
         catch (Exception e)
         {
-            Utils.writeErrorMessage("Error finding resource - " + e.getMessage());
-            throw e;
+            if (e.getMessage().contains("Status code 404"))
+                return null;
+            Utils.writeWarningMessage("Error finding resource - " + e.getMessage());
         }
 
-        return CompletableFuture.completedFuture(null);
+        return null;
     }
 
     /**
@@ -84,7 +80,7 @@ public class CommonSdk
      * @param resourceId Resource id of the resource that was deleted
      * @param clazz Valid class types: NetAppAccountInner, CapacityPoolInner, VolumeInner, SnapshotInner, SnapshotPolicyInner
      */
-    public static <T> void waitForNoANFResource(AzureNetAppFilesManagementClientImpl anfClient, String resourceId, Class<T> clazz)
+    public static <T> void waitForNoANFResource(NetAppManagementClient anfClient, String resourceId, Class<T> clazz)
     {
         waitForNoANFResource(anfClient, resourceId, 10, 60, clazz);
     }
@@ -98,7 +94,7 @@ public class CommonSdk
      * @param retries Number of times polling will be performed
      * @param clazz Valid class types: NetAppAccountInner, CapacityPoolInner, VolumeInner, SnapshotInner, SnapshotPolicyInner
      */
-    public static <T> void waitForNoANFResource(AzureNetAppFilesManagementClientImpl anfClient, String resourceId, int intervalInSec, int retries, Class<T> clazz)
+    public static <T> void waitForNoANFResource(NetAppManagementClient anfClient, String resourceId, int intervalInSec, int retries, Class<T> clazz)
     {
         for (int i = 0; i < retries; i++)
         {
@@ -109,51 +105,49 @@ public class CommonSdk
                 switch (clazz.getSimpleName())
                 {
                     case "NetAppAccountInner":
-                        Observable<NetAppAccountInner> account = anfClient.accounts().getByResourceGroupAsync(ResourceUriUtils.getResourceGroup(resourceId),
+                        NetAppAccountInner account = anfClient.getAccounts().getByResourceGroup(ResourceUriUtils.getResourceGroup(resourceId),
                                 ResourceUriUtils.getAnfAccount(resourceId));
-                        if (account.toBlocking().first() == null)
+                        if (account == null)
                             return;
 
                         continue;
 
                     case "SnapshotPolicyInner":
-                        Observable<SnapshotPolicyInner> snapshotPolicy = anfClient.snapshotPolicies().getAsync(ResourceUriUtils.getResourceGroup(resourceId),
+                        SnapshotPolicyInner snapshotPolicy = anfClient.getSnapshotPolicies().get(ResourceUriUtils.getResourceGroup(resourceId),
                                 ResourceUriUtils.getAnfAccount(resourceId),
                                 ResourceUriUtils.getAnfSnapshotPolicy(resourceId));
-                        if (snapshotPolicy.toBlocking().first() == null)
+                        if (snapshotPolicy == null)
                             return;
 
                         continue;
 
                     case "CapacityPoolInner":
-                        Observable<CapacityPoolInner> pool = anfClient.pools().getAsync(ResourceUriUtils.getResourceGroup(resourceId),
+                        CapacityPoolInner pool = anfClient.getPools().get(ResourceUriUtils.getResourceGroup(resourceId),
                                 ResourceUriUtils.getAnfAccount(resourceId),
                                 ResourceUriUtils.getAnfCapacityPool(resourceId));
-                        if (pool.toBlocking().first() == null)
+                        if (pool == null)
                             return;
 
                         continue;
 
                     case "VolumeInner":
-                        Observable<VolumeInner> volume = anfClient.volumes().getAsync(ResourceUriUtils.getResourceGroup(resourceId),
+                        VolumeInner volume = anfClient.getVolumes().get(ResourceUriUtils.getResourceGroup(resourceId),
                                 ResourceUriUtils.getAnfAccount(resourceId),
                                 ResourceUriUtils.getAnfCapacityPool(resourceId),
                                 ResourceUriUtils.getAnfVolume(resourceId));
-                        if (volume.toBlocking().first() == null)
+                        if (volume == null)
                             return;
 
                         continue;
 
                     case "SnapshotInner":
-                        Observable<SnapshotInner> snapshot = anfClient.snapshots().getAsync(ResourceUriUtils.getResourceGroup(resourceId),
+                        SnapshotInner snapshot = anfClient.getSnapshots().get(ResourceUriUtils.getResourceGroup(resourceId),
                                 ResourceUriUtils.getAnfAccount(resourceId),
                                 ResourceUriUtils.getAnfCapacityPool(resourceId),
                                 ResourceUriUtils.getAnfVolume(resourceId),
                                 ResourceUriUtils.getAnfSnapshot(resourceId));
-                        if (snapshot.toBlocking().first() == null)
+                        if (snapshot == null)
                             return;
-
-                        continue;
                 }
             }
             catch (Exception e)

--- a/src/main/java/dualprotocol/sdk/sample/common/CommonSdk.java
+++ b/src/main/java/dualprotocol/sdk/sample/common/CommonSdk.java
@@ -8,8 +8,6 @@ package dualprotocol.sdk.sample.common;
 import com.azure.resourcemanager.netapp.fluent.NetAppManagementClient;
 import com.azure.resourcemanager.netapp.fluent.models.*;
 
-import java.util.concurrent.CompletableFuture;
-
 // Contains public methods for SDK related operations
 public class CommonSdk
 {

--- a/src/main/java/dualprotocol/sdk/sample/common/Utils.java
+++ b/src/main/java/dualprotocol/sdk/sample/common/Utils.java
@@ -5,9 +5,6 @@
 
 package dualprotocol.sdk.sample.common;
 
-import com.microsoft.azure.credentials.ApplicationTokenCredentials;
-import com.microsoft.rest.credentials.ServiceClientCredentials;
-
 import java.io.Console;
 import java.io.File;
 import java.io.IOException;
@@ -98,41 +95,6 @@ public class Utils
         return String.valueOf(console.readPassword());
     }
 
-    /**
-     * Gets service principal based credentials
-     * @param authEnvironmentVariable Environment variable that points to the file system secured azure auth settings
-     * @return The service client credentials
-     */
-    public static ServiceClientCredentials getServicePrincipalCredentials(String authEnvironmentVariable)
-    {
-        if (authEnvironmentVariable == null)
-        {
-            Utils.writeWarningMessage("Environment variable AZURE_AUTH_LOCATION does not exist. Exiting");
-            return null;
-        }
-
-        File file = new File(authEnvironmentVariable);
-        if (!file.exists())
-        {
-            Utils.writeWarningMessage("Could not find azure auth file at " + authEnvironmentVariable + " to authenticate. Exiting");
-            return null;
-        }
-
-        ApplicationTokenCredentials credentials;
-        try
-        {
-            credentials = ApplicationTokenCredentials.fromFile(file);
-        }
-        catch (IOException e)
-        {
-            Utils.writeWarningMessage("Unable to create credentials from auth file\n");
-            Utils.writeConsoleMessage(e.getMessage());
-            return null;
-        }
-
-        return credentials;
-    }
-
     public static String getRootCACert(String certLocation)
     {
         try
@@ -145,7 +107,6 @@ public class Utils
             return null;
         }
     }
-
 
     private static class ConsoleColors
     {

--- a/src/main/java/dualprotocol/sdk/sample/main.java
+++ b/src/main/java/dualprotocol/sdk/sample/main.java
@@ -6,6 +6,7 @@
 package dualprotocol.sdk.sample;
 
 import com.azure.core.credential.TokenCredential;
+import com.azure.core.exception.AzureException;
 import com.azure.core.management.AzureEnvironment;
 import com.azure.core.management.profile.AzureProfile;
 import com.azure.identity.DefaultAzureCredentialBuilder;
@@ -198,7 +199,7 @@ public class main
                 CommonSdk.waitForNoANFResource(manager.serviceClient(), anfAccount.id(), NetAppAccountInner.class);
                 Utils.writeSuccessMessage("Account successfully deleted: " + anfAccount.id());
             }
-            catch (Exception e)
+            catch (AzureException e)
             {
                 Utils.writeConsoleMessage("An error occurred while deleting resource: " + e.getMessage());
                 throw e;


### PR DESCRIPTION
Update to sdk version 1.0.0-beta.5
Minimum changes made to support the new sdk version
- Use TokenCredential with AzureProfile instead of ServiceClientCredentials
- Use NetAppFilesManager instead of AzureNetAppFilesManagementClientImpl
- Remove Observables and CompletableFuture since it is not supported any more.
- Updated readme file to describe new way to authenticate